### PR TITLE
Bump json to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     http (0.5.0)
       http_parser.rb
     http_parser.rb (0.6.0)
-    json (1.8.1)
+    json (1.8.2)
     memoizable (0.4.0)
       thread_safe (~> 0.1.3)
     multipart-post (2.0.0)


### PR DESCRIPTION
Per flori/json#229, json 1.8.1 is incompatible with Ruby 2.2.0 (and possibly greater).

This bumps the json gem to a 2.2.0-compatible version.
